### PR TITLE
Improve markdown

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,9 @@
 # yamllint-maven-plugin
 yamllint provided as a maven plugin using com.github.sbaudoin:yamllint
 
-#Usage
+## Usage 
+
+```xml
     <plugin>
         <groupId>com.isycat</groupId>
         <artifactId>yamllint-maven-plugin</artifactId>
@@ -19,7 +21,7 @@ yamllint provided as a maven plugin using com.github.sbaudoin:yamllint
             </execution>
         </executions>
     </plugin>
+```
 
-
-#Configuration
+## Configuration
 For linter configuration please refer to https://github.com/sbaudoin/yamllint#configuration


### PR DESCRIPTION
Before the README was not rendered nicely on GitHub

Before:
<img width="920" alt="image" src="https://github.com/isycat/yamllint-maven-plugin/assets/30121440/c3d1a0f8-4031-4b49-8ddb-095470668014">

After:
<img width="915" alt="image" src="https://github.com/isycat/yamllint-maven-plugin/assets/30121440/a1c08a6d-3789-4475-a9e9-7dad1350e0c7">
